### PR TITLE
Use generic snapshots folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,12 +46,12 @@ script:
   - for i in {30..0}; do docker exec -it m0 /usr/local/bin/backup.sh > /dev/null; sleep 1; done
 
   # Check that only 20 backups are kept
-  - "bkup_count=$(docker exec -it m0 ls -l /data/backups | grep tar.gz | wc -l)"
+  - "bkup_count=$(docker exec -it m0 ls -l /snapshots | grep tar.gz | wc -l)"
   - '[ "$bkup_count" == "20" ]'
 
   # Perform recovery and check integrity
   - docker exec -it m0 mkdir -p /tmp/restore
-  - docker exec -it m0 bash -c "tar -C /tmp/restore -xvzf \$(ls -1r /data/backups/*.tar.gz | head -n 1)"
+  - docker exec -it m0 bash -c "tar -C /tmp/restore -xvzf \$(ls -1r /snapshots/*.tar.gz | head -n 1)"
   - docker exec -it m0 mongorestore -u root -p root --drop /tmp/restore
   - "record_count=$(mongo -u root -p root --authenticationDatabase admin --quiet --eval 'db.dummy.count()' $HOST_PUB_IP:$PORT_NODE_0/app_db)"
   - '[ "$record_count" == "10" ]'

--- a/2.6/Dockerfile
+++ b/2.6/Dockerfile
@@ -3,8 +3,8 @@ FROM mongo:2.6
 # Point-in-time backup script with backup rotation
 COPY backup.sh /usr/local/bin/
 
-# Extend mountable directory
-VOLUME ["/data"]
+# Persistent folders
+VOLUME ["/data","/snapshots"]
 
 # Entrypoint command
 COPY docker-entrypoint.sh /usr/local/bin/

--- a/2.6/backup.sh
+++ b/2.6/backup.sh
@@ -6,7 +6,7 @@
 set -e
 
 # Configuration
-BKUP_DIR=${BKUP_DIR:-"/data/backups"}
+BKUP_DIR=${BKUP_DIR:-"/snapshots"}
 BKUP_RETENTION=${BKUP_RETENTION:-20}
 
 # Ensure backup directory exists
@@ -15,9 +15,10 @@ mkdir -p $BKUP_DIR
 # Perform backup
 ts=$(date -u +"%Y-%m-%dT%H-%M-%SZ")
 mkdir -p $BKUP_DIR/$ts
-mongodump -u $MONGO_USER -p $MONGO_PASSWORD --oplog --out $BKUP_DIR/$ts/
-tar -zcvf $BKUP_DIR/$ts.tar.gz $BKUP_DIR/$ts/
-rm -rf ${BKUP_DIR:?}/$ts
+mongodump -u $MONGO_USER -p $MONGO_PASSWORD --oplog --out /tmp/$ts/
+tar -zcvf /tmp/$ts.tar.gz /tmp/$ts/
+rm -rf /tmp/$ts
+mv /tmp/$ts.tar.gz $BKUP_DIR/
 
 # Keep limited number of backups
 ls -1 $BKUP_DIR/*.tar.gz | head -n -${BKUP_RETENTION} | xargs -d '\n' rm -f --


### PR DESCRIPTION
- Use standard "/snapshots" folder for backups (used across all images with persistent data)
- Ensure backups are atomic